### PR TITLE
🔨 Fix: #18 CameraListView의 버튼 터치 영역이 Text로 한정되어 있는 문제

### DIFF
--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/Onboarding/CameraItemListView.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/Onboarding/CameraItemListView.swift
@@ -20,11 +20,13 @@ struct CameraItemListView<Item: Identifiable & Equatable>: View {
                     Button {
                         selectedItem = item
                     } label: {
-                        Text(label(item))
-                            .foregroundColor(selectedItem == item ? .hhcolor(.text(.white)) : .hhcolor(.text(.primary)))
-                            .font(.body)
+                        HStack {
+                            Text(label(item))
+                                .foregroundColor(selectedItem == item ? .hhcolor(.text(.white)) : .hhcolor(.text(.primary)))
+                                .font(.body)
+                            Spacer()
+                        }
                     }
-                    .buttonStyle(.plain)
                     .listRowBackground((selectedItem == item ? .hhcolor(.buttonBackground(.primary)) : Color.clear))
                 }
             }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #18 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- `CameraItemListView`의 터치 영역을 수정했습니다.

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16 pro, iOS 18.5 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
