### PR TITLE
🔨 Fix: #29 잠금 버튼 눌렀을 때 EV값 및 카메라 프리뷰 멈추지 않는 문제

### DIFF
--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterRepresentable.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterRepresentable.swift
@@ -1,5 +1,5 @@
 //
-//  ExposureMeterRepersentable.swift
+//  ExposureMeterRepresentable.swift
 //  HonestHouse-Prototype
 //
 //  Created by Rama on 9/30/25.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ExposureMeterRepersentable: UIViewRepresentable {
+struct ExposureMeterRepresentable: UIViewRepresentable {
     @Binding var ev: Double
     var onStabilized: () -> Void
     var onUnstabilized: () -> Void

--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterRepresentable.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterRepresentable.swift
@@ -11,6 +11,8 @@ struct ExposureMeterRepresentable: UIViewRepresentable {
     @Binding var ev: Double
     var onStabilized: () -> Void
     var onUnstabilized: () -> Void
+    
+    @Binding var isPaused: Bool
 
     func makeUIView(context: Context) -> ExposureMeterUIView {
         let view = ExposureMeterUIView()
@@ -36,5 +38,7 @@ struct ExposureMeterRepresentable: UIViewRepresentable {
         return view
     }
 
-    func updateUIView(_ uiView: ExposureMeterUIView, context: Context) {}
+    func updateUIView(_ uiView: ExposureMeterUIView, context: Context) {
+        uiView.setPaused(isPaused)
+    }
 }

--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterUIView.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterUIView.swift
@@ -31,6 +31,8 @@ class ExposureMeterUIView: UIView {
     private let stabilizationThreshold: Double = 1.0
     private let stabilizationDuration: TimeInterval = 3.0
     
+    private var readTimer: Timer?
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -99,6 +101,7 @@ class ExposureMeterUIView: UIView {
         }
         
         session.commitConfiguration()
+        resume()
         
         DispatchQueue.global(qos: .background).async {
             self.session.startRunning()
@@ -111,8 +114,21 @@ class ExposureMeterUIView: UIView {
         }
     }
     
+    private func startReadingEV() {
+        stopReadingEV()
+        readTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            self?.readExposureValues()
+        }
+        RunLoop.main.add(readTimer!, forMode: .common)
+    }
+    
+    private func stopReadingEV() {
+        readTimer?.invalidate()
+                readTimer = nil
+    }
+    
     private func readExposureValues() {
-        guard let device = device else { return }
+        guard !isPaused, let device = device else { return }
         
         let iso = device.iso
         let exposure = device.exposureDuration.seconds
@@ -172,5 +188,31 @@ class ExposureMeterUIView: UIView {
                 onUnstabilized?()
             }
         }
+    }
+    
+    func setPaused(_ paused: Bool) {
+        guard paused != isPaused else { return }
+        isPaused = paused
+        if paused {
+            pause()
+        } else {
+            resume()
+        }
+    }
+    
+    private func pause() {
+        previewLayer?.connection?.isEnabled = false
+        stopReadingEV()
+        if session.isRunning {
+            DispatchQueue.global(qos: .background).async { self.session.stopRunning() }
+        }
+    }
+    
+    private func resume() {
+        if !session.isRunning {
+            DispatchQueue.global(qos: .background).async { self.session.startRunning() }
+        }
+        previewLayer?.connection?.isEnabled = true
+        startReadingEV()
     }
 }

--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterUIView.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterUIView.swift
@@ -25,6 +25,7 @@ class ExposureMeterUIView: UIView {
     var onUnstabilized: (() -> Void)?
     
     private var isCurrentlyStabilized = false
+    private var isPaused = false
     
     private var evHistory: [(value: Double, timestamp: Date)] = []
     private let stabilizationThreshold: Double = 1.0

--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterView.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterView.swift
@@ -40,7 +40,7 @@ struct ExposureMeterView: View {
     
     var body: some View {
         ZStack {
-            ExposureMeterRepersentable(
+            ExposureMeterRepresentable(
                 ev: $ev,
                 onStabilized: {
                     isStabilized = true

--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterView.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterView.swift
@@ -47,7 +47,8 @@ struct ExposureMeterView: View {
                 },
                 onUnstabilized: {
                     isStabilized = false
-                }
+                },
+                isPaused: $showDetailValue
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .ignoresSafeArea(.all, edges: .all)


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #29 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- `ExposureMeterUIView`에 프리뷰 일시정지/재개 기능 추가 (setPaused)
- `showDetailValue` 상태와 카메라 프리뷰 동기화 (상세 뷰 보이면 정지, 닫으면 재개)

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15 pro, iOS 26.0 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->


---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

