### PR TITLE
🔨 Fix: #37 ExposureDetailView가 보일 때 SolarRotation이 멈추지 않는 문제

### DIFF
--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Core/Services/SolarManager.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Core/Services/SolarManager.swift
@@ -28,18 +28,14 @@ public final class SolarManager: ObservableObject {
     @discardableResult
     public func refresh(at date: Date = Date()) -> SunStatus {
         let position = SolarPosition.compute(latitude: latitude, longitude: longitude, date: date)
+
+        elevation = position.elevation
+        azimuth = position.azimuth
+
         let newStatus: SunStatus = (position.elevation > -0.833)
             ? .sunUp(elevation: position.elevation, azimuth: position.azimuth)
             : .noSun
-        
-        switch newStatus {
-        case .sunUp(let elev, let az):
-            elevation = elev
-            azimuth = az
-        case .noSun:
-            elevation = nil
-            azimuth = nil
-        }
+
         status = newStatus
         return newStatus
     }

--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterView.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterView.swift
@@ -67,7 +67,10 @@ struct ExposureMeterView: View {
                 Spacer()
                 
                 ZStack(alignment: .center) {
-                    SolarRotationView(isBacklit: $isBacklit)
+                    SolarRotationView(
+                        isBacklit: $isBacklit,
+                        isPaused: showDetailValue || !SolarManager.shared.status.isSunUp
+                    )
                     exposureLockButton()
                     if !showDetailValue {
                         HStack {


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #37 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- `ExposureDetailView`가 표시될 때 `SolarRotationView`가 계속 회전하던 문제 수정
  - `SolarRotationView`에 `isPaused` 추가 -> `showDetailValue`가 `true`일 때 회전/타이머/헤딩 업데이트 정지
  - `isSunUp == false`일 때도 이미지 숨김 뿐만 아니라 회전 자체를 멈추도록 개선
- `SolarManager.refresh()` 로직 개선
  - 밤(`noSun`)에도 `elevation`/`azimuth` 값을 유지
  - status는 기존대로 `.sunUp`/`.noSun`으로 구분, UI는 상태에 따라 제어

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15 pro, iOS 26.0 환경에서 정상 동작
- [x] 밤에 `isSunUp`에 강제로 true를 주입하여 테스트
  - [ ] 낮에도 정상 동작하는지 확인 필요

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

**고민한 지점:**
- 밤에도 좌표값을 nil로 초기화해야 하는가? -> `status.isSunUp`으로 노출을 제어하므로 nil 초기화는 불필요하다고 판단

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
