### PR TITLE
✨ Fix: #39 측광 로직에서 Race Condition 에러 수정

### DIFF
--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureDetailView.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureDetailView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct ExposureDetailView: View {
     @Binding var ev: Double
     @Binding var mode: String
-    @Binding var baseExposure: ExposureSetting?
     @Binding var spectrum: [ExposureSetting]
     @Binding var response: String
     @Binding var showDetailValue: Bool
@@ -105,20 +104,29 @@ struct ExposureDetailView: View {
                     }
                     
                     HStack {
-                        Text("ISO:")
-                            .font(.system(size: 20, weight: .semibold))
-                            .foregroundStyle(SolarManager.shared.status.isSunUp ? Color.black : Color.white)
-                        if let baseExposure = baseExposure {
-                            Text("\(baseExposure.iso)")
-                                .font(.system(size: 16, weight: .medium, design: .monospaced))
-                                .padding(.horizontal, 4)
-                                .padding(.vertical, 2)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 4)
-                                        .fill(.hhcolor(color: .buttonBackground(.disabled)))
-                                )
+                        if let first = spectrum.first,
+                           let last = spectrum.last {
+                            Text("ISO:")
+                                .font(.system(size: 20, weight: .semibold))
+                                .foregroundStyle(SolarManager.shared.status.isSunUp ? Color.black : Color.white)
+                            
+                            Group {
+                                Text("\(first.iso)")
+                                if first.iso != last.iso {
+                                    Text("-")
+                                    Text("\(last.iso)")
+                                }
+                            }
+                            .font(.system(size: 16, weight: .medium, design: .monospaced))
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 2)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(.hhcolor(color: .buttonBackground(.disabled)))
+                            )
+
+                            Spacer()
                         }
-                        Spacer()
                     }
                     
                     HStack {

--- a/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterView.swift
+++ b/HonestHouse-Prototype/HonestHouse-Prototype/Sources/Presentation/ExposureMeter/ExposureMeterView.swift
@@ -88,7 +88,6 @@ struct ExposureMeterView: View {
                 ExposureDetailView(
                     ev: $ev,
                     mode: $mode,
-                    baseExposure: $baseExposure,
                     spectrum: $exposureSpectrum,
                     response: $response,
                     showDetailValue: $showDetailValue,


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #39 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- AVCaptureSession Condition Race 오류 수정
- ExposureDetail 뷰의 ISO를 Spectrum 값으로 대체

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->
| ISO 스펙트럼이 있을 때 | 단일 ISO일 때 |
|:---:|:---:|
|<img width="300" height="1278" alt="IMG_5708" src="https://github.com/user-attachments/assets/584753ea-bee0-49fe-a34c-2ad1578aec4b" />|<img width="300" height="1278" alt="IMG_5709" src="https://github.com/user-attachments/assets/46cd55af-0b43-4e4d-a091-0f125c539846" />|


---

### 🧪 테스트 / 검증 내역

- [x] X Button 눌러 Camera Session 시작될 때 session Breakpoint 확인
- [x] ISO Sprctrum이 있을 때/없을 때 Break Point 로그 찍어 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->
- Race Condition 발생 원인은 아래 초기화 부분 코드에서 뷰가 초기화될 때마다 session을 재실행했기 때문입니다.
```
 override init(frame: CGRect) {
        super.init(frame: frame)
        
        setCameraSession()
    }
```
- 그래서 setCameraSession()에 세션이 진행중인지 플래그를 넣어 불필요한 세션 재실행을 막았습니다.
```
    private func setCameraSession() {
        guard !hasConfigured else { return }
        hasConfigured = true
        
        configureSession()
        setPreviewLayer()
        finishSessionSetting()
    }
```
---
